### PR TITLE
Fix linkplay based device becoming unresponsive to airplay commands

### DIFF
--- a/src/cliraop.c
+++ b/src/cliraop.c
@@ -148,6 +148,9 @@ static void close_platform()
 /*----------------------------------------------------------------------------*/
 static void *CmdPipeReaderThread(void *args)
 {
+	uint64_t last_keepalive;  // Track last keepalive time
+
+	last_keepalive = raopcl_get_ntp(NULL);  // Initialize last keepalive time
 	// O_RDWR keeps the pipe open even when no writer is connected
 	cmdPipeFd = open(cmdPipeName, O_RDWR | O_NONBLOCK);
 	if (cmdPipeFd == -1)
@@ -168,8 +171,25 @@ static void *CmdPipeReaderThread(void *args)
 
 	while (glMainRunning)
 	{
-		ssize_t bytes_read = read(cmdPipeFd, cmdPipeBuf, sizeof(cmdPipeBuf) - 1);
+		struct pollfd pfds;
 
+		pfds.fd = cmdPipeFd;
+		pfds.events = POLLIN;
+
+		int n = poll(&pfds, 1, 1000);
+		if (!glMainRunning)
+			break;
+
+		uint64_t now = raopcl_get_ntp(NULL);
+		// Send keepalive packet every 20 seconds
+		if (now - last_keepalive >= MS2NTP(20000)) {
+			LOG_INFO("[%p]: sending keepalive packet", raopcl);
+			raopcl_keepalive(raopcl);
+			last_keepalive = now;
+		}
+		if (n <= 0 || !(pfds.revents & POLLIN)) continue;
+
+		ssize_t bytes_read = read(cmdPipeFd, cmdPipeBuf, sizeof(cmdPipeBuf) - 1);
 		if (bytes_read > 0)
 		{
 			cmdPipeBuf[bytes_read] = '\0';
@@ -298,19 +318,8 @@ static void *CmdPipeReaderThread(void *args)
 		}
 		else if (bytes_read < 0)
 		{
-			if (errno == EAGAIN || errno == EWOULDBLOCK)
-			{
-				usleep(50 * 1000);
-			}
-			else
-			{
-				LOG_ERROR("Error reading from command pipe: %s", strerror(errno));
-				usleep(250 * 1000);
-			}
-		}
-		else
-		{
-			usleep(50 * 1000);
+			LOG_ERROR("Error reading from command pipe: %s", strerror(errno));
+			usleep(250 * 1000);
 		}
 	}
 	return NULL;
@@ -667,7 +676,6 @@ int main(int argc, char *argv[])
 	status = PLAYING;
 
 	buf = malloc(DEFAULT_FRAMES_PER_CHUNK * 4);
-	uint32_t KeepAlive = 0;
 	bool got_eof = false;
 
 	// keep reading audio from stdin until exit/EOF
@@ -686,10 +694,6 @@ int main(int argc, char *argv[])
 			{
 				LOG_INFO("elapsed milliseconds: %" PRIu64, elapsed);
 			}
-
-			// send keepalive when needed (to prevent stop playback on homepods)
-			if (!(KeepAlive++ & 0x0f))
-				raopcl_keepalive(raopcl);
 		}
 
 		// send chunk if needed

--- a/src/raop_client.c
+++ b/src/raop_client.c
@@ -130,7 +130,6 @@ typedef struct {
 typedef struct raopcl_s {
 	struct rtspcl_s *rtspcl;
 	raop_state_t state;
-	uint64_t last_keepalive;  // Track last keepalive time
 	char DACP_id[17], active_remote[11];
 	struct {
 		unsigned int ctrl, time;
@@ -677,7 +676,6 @@ struct raopcl_s *raopcl_create(struct in_addr host, uint16_t port_base, uint16_t
 	raopcld = malloc(sizeof(raopcl_data_t));
 	memset(raopcld, 0, sizeof(raopcl_data_t));
 
-	raopcld->last_keepalive = raopcl_get_ntp(NULL);  // Initialize last keepalive time
 	//  raopcld->sane is set to 0
 	raopcld->port_base = port_base;
 	raopcld->port_range = port_base ? port_range : 1;
@@ -1138,7 +1136,6 @@ bool _raopcl_disconnect(struct raopcl_s *p, bool force)
 
 	pthread_mutex_lock(&p->mutex);
 	p->state = RAOP_DOWN;
-	p->last_keepalive = raopcl_get_ntp(NULL);
 	pthread_mutex_unlock(&p->mutex);
 
 	_raopcl_terminate_rtp(p);
@@ -1362,14 +1359,6 @@ void *_rtp_control_thread(void *args)
 	while (raopcld->ctrl_running)	{
 		struct timeval timeout = { 1, 0 };
 		fd_set rfds;
-		uint64_t now = raopcl_get_ntp(NULL);
-
-		// Send keepalive packet every 25 seconds
-		if (now - raopcld->last_keepalive >= MS2NTP(25000)) {
-			LOG_INFO("[%p]: sending keepalive packet", raopcld);
-			raopcl_keepalive(raopcld);
-			raopcld->last_keepalive = now;
-		}
 
 		FD_ZERO(&rfds);
 		FD_SET(raopcld->rtp_ports.ctrl.fd, &rfds);

--- a/src/rtsp_client.c
+++ b/src/rtsp_client.c
@@ -662,7 +662,7 @@ static bool exec_request(struct rtspcl_s *rtspcld, char *cmd, char *content_type
 
 	// ignore 501 when 
 	if (token == NULL || strcmp(token, "200")) {
-		if (strcmp(token, "501") || strcmp(cmd, "OPTIONS")) {
+		if (token == NULL || strcmp(token, "501") || strcmp(cmd, "OPTIONS")) {
 			LOG_ERROR("[%p]: <------ : request failed, error %s %s", rtspcld, line, (token ? token : ""));
 		}
 		if (get_response == 1) return false;


### PR DESCRIPTION
There are a couple things reviewers should be aware of.

With this change, keepalive commands are only sent when the `-cmdpipe` cli option is specified. I believe this is OK for music assistant usage. But if you have future plans of using this library in other contexts, this should be considered.

Second, I removed some `usleep()` calls that I believe I've made unnecessary.  I think they were added to prevent unbounded CPU usage when O_NONBLOCK was added to the flags when opening the command pipe.  And I believe that O_NONBLOCK was only added to allow opening of the pipe before the other end of the pipe has been opened. I've added a `poll()` that eliminates this need for extra usleeps.

There are 2 fixes here, separated into 2 commits.  

The first is a segfault that can occur in an error path. It's a straight forward NULL check.

The second fixes a concurrency issue that causes my linkplay based devices to become unresponsive to airplay commands. The keepalive command was being sent on a different thread than all the other commands.  Occasionally it would be sent concurrently with some other command. This puts the linkplay device into a bad state that it does not recover from until the stream is shut down.

Fixes https://github.com/music-assistant/support/issues/4720