### PR TITLE
Fix crash in rtspcl_auth_setup when response body is empty

### DIFF
--- a/src/rtsp_client.c
+++ b/src/rtsp_client.c
@@ -501,8 +501,8 @@ bool rtspcl_auth_setup(struct rtspcl_s *p) {
 	if (!p) return false;
 
 	uint8_t secret[SECRET_KEY_SIZE], * pub_key = malloc(PUBLIC_KEY_SIZE + 1);
-	uint8_t* rsp;
-	int rsp_len;
+	uint8_t* rsp = NULL;  // Initialize to NULL - may not be set if no response body
+	int rsp_len = 0;
 
 	// create a verification public key
 	RAND_bytes(secret, SECRET_KEY_SIZE);


### PR DESCRIPTION
## Summary
When connecting to Shairport Sync devices that return an empty body (Content-Length: 0) for the `/auth-setup` request, the `rsp` pointer was never assigned but was still freed at the end of the function, causing a malloc error: `pointer being freed was not allocated`.

## The Fix
Initialize `rsp` to `NULL` and `rsp_len` to `0` in `rtspcl_auth_setup()`, so that `free(rsp)` is safe when no response body is received.

## Testing
Tested successfully with JukeAudio whole-house audio systems running Shairport Sync 4.1.1. Before the fix, cliraop would crash immediately when trying to stream. After the fix, streaming works correctly.

## Root Cause Analysis
The issue occurs in `src/rtsp_client.c` lines 503-504:
```c
uint8_t* rsp;      // uninitialized
int rsp_len;       // uninitialized
```

When Shairport Sync returns a 200 OK with `Content-Length: 0` to the auth-setup request, the `exec_request` function never assigns `rsp` (since there's no body to read). However, line 529 still calls `free(rsp)`, which tries to free an uninitialized pointer.

related: https://github.com/music-assistant/support/issues/4656