### PR TITLE
Expose the RTSP status of a failed connect

### DIFF
--- a/src/raop_client.c
+++ b/src/raop_client.c
@@ -129,6 +129,9 @@ typedef struct {
 
 typedef struct raopcl_s {
 	struct rtspcl_s *rtspcl;
+	// RTSP status seen when raopcl_connect last failed, sampled before the
+	// teardown exchanges overwrite it (MA cliairplay addition)
+	int connect_status;
 	raop_state_t state;
 	uint64_t last_keepalive;  // Track last keepalive time
 	char DACP_id[17], active_remote[11];
@@ -209,6 +212,12 @@ uint32_t raopcl_sample_rate(struct raopcl_s *p)
 {
 	if (!p) return 0;
 	return p->sample_rate;
+}
+
+/*----------------------------------------------------------------------------*/
+int raopcl_connect_rtsp_status(struct raopcl_s *p)
+{
+	return p ? p->connect_status : 0;
 }
 
 /*----------------------------------------------------------------------------*/
@@ -980,6 +989,7 @@ bool raopcl_connect(struct raopcl_s *p, struct in_addr peer, uint16_t destport, 
 
 	if (peer.s_addr != INADDR_ANY) p->peer_addr.s_addr = peer.s_addr;
 	if (destport != 0) p->rtsp_port = destport;
+	p->connect_status = 0;
 
 	RAND_bytes((uint8_t*) &p->ssrc, sizeof(p->ssrc));
 	VALGRIND_MAKE_MEM_DEFINED(&p->ssrc, sizeof(p->ssrc));
@@ -1093,6 +1103,8 @@ bool raopcl_connect(struct raopcl_s *p, struct in_addr peer, uint16_t destport, 
 	return true;
 
  erexit:
+	// sample the failing status before the teardown exchanges below replace it
+	p->connect_status = rtspcl_last_status(p->rtspcl);
 	if (sac) free(sac);
 	kd_free(kd);
 	_raopcl_disconnect(p, true);

--- a/src/raop_client.h
+++ b/src/raop_client.h
@@ -155,6 +155,10 @@ void 	raopcl_stop(struct raopcl_s *p);
 */
 uint32_t 	raopcl_latency(struct raopcl_s *p);
 uint32_t 	raopcl_sample_rate(struct raopcl_s *p);
+// RTSP status seen when raopcl_connect last failed (0 when none): tells a
+// rejected password (401) from a device that never answered (MA cliairplay
+// addition)
+int			raopcl_connect_rtsp_status(struct raopcl_s *p);
 raop_state_t raopcl_state(struct raopcl_s *p);
 uint32_t 	raopcl_queue_len(struct raopcl_s *p);
 

--- a/src/rtsp_client.c
+++ b/src/rtsp_client.c
@@ -48,6 +48,9 @@ typedef struct rtspcl_s {
 		char realm[16], nonce[256+1];
 		char ha1[32+1];
 	} digest;
+	// status of the last RTSP response read, so callers can tell a rejected
+	// password (401) from an unreachable device (MA cliairplay addition)
+	int last_status;
 } rtspcl_t;
 
 extern log_level 	raop_loglevel;
@@ -61,6 +64,11 @@ static bool exec_request(rtspcl_t *rtspcld, char *cmd, char *content_type,
 /*----------------------------------------------------------------------------*/
 int rtspcl_get_serv_sock(struct rtspcl_s *p) {
 	return p->fd;
+}
+
+/*----------------------------------------------------------------------------*/
+int rtspcl_last_status(struct rtspcl_s *p) {
+	return p ? p->last_status : 0;
 }
 
 /*----------------------------------------------------------------------------*/
@@ -98,6 +106,7 @@ bool rtspcl_is_sane(struct rtspcl_s *p) {
 bool rtspcl_connect(struct rtspcl_s *p, struct in_addr local, struct in_addr host, uint16_t destport, char *sid) {
 	if (!p) return false;
 
+	p->last_status = 0;
 	p->session = NULL;
 	if ((p->fd = open_tcp_socket(local, NULL, true)) == -1) return false;
 	if (!tcp_connect_by_host(p->fd, host, destport)) return false;
@@ -659,6 +668,9 @@ static bool exec_request(struct rtspcl_s *rtspcld, char *cmd, char *content_type
 
 	token = strtok(line, delimiters);
 	token = strtok(NULL, delimiters);
+
+	rtspcld->last_status = 0;
+	if (token) sscanf(token, "%d", &rtspcld->last_status);
 
 	// ignore 501 when used with OPTIONS
 	if (token == NULL || strcmp(token, "200")) {

--- a/src/rtsp_client.h
+++ b/src/rtsp_client.h
@@ -25,6 +25,9 @@ typedef struct rtp_port_s {
 
 struct rtspcl_s *rtspcl_create(char* user_name);
 bool   			rtspcl_destroy(struct rtspcl_s *p);
+// status of the last RTSP response read (0 when none): tells a rejected
+// password (401) from a device that never answered (MA cliairplay addition)
+int				rtspcl_last_status(struct rtspcl_s *p);
 
 bool rtspcl_connect(struct rtspcl_s *p, struct in_addr local, struct in_addr host, unsigned short destport, char *sid);
 bool rtspcl_disconnect(struct rtspcl_s *p);


### PR DESCRIPTION
cliairplay needs to tell a rejected password (RTSP 401/403) apart from a device that is simply unreachable, so Music Assistant can show a proper "wrong password" message instead of a generic connect failure. libraop discards the RTSP status of a failed connect today.

- Record the status of the last RTSP response read (`rtspcl_last_status`), reset on connect
- Sample it when `raopcl_connect` fails, before the teardown exchanges overwrite it, exposed as `raopcl_connect_rtsp_status`
- 31 added lines, no behavior change

Note: this PR is based on the `cliairplay-base` branch (the upstream commit the cliairplay submodule currently pins, `81c2182`) rather than `master`, because `master` has diverged from that pin. Companion PR: the cliairplay password-auth PR switches its submodule to this fork and points at this branch.
